### PR TITLE
Remove equal check and base on req/s diff

### DIFF
--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -45,13 +45,10 @@ if (choices.length === 0) {
     }]).then(function (secondChoice) {
       let [a, b] = [firstChoice.choice, secondChoice.choice]
       let result = compare(a, b)
-      if (result === true) {
-        console.log(chalk.green.bold(`${a} and ${b} both are fast!`))
-      } else {
-        console.log(chalk.blue(`Both are awesome but`), chalk.bold.green(result.fastest), chalk.blue(`is`), chalk.red(result.diff), chalk.blue(`faster than`), chalk.bold.yellow(result.slowest))
-        console.log(chalk.bold.green(result.fastest), chalk.blue(`request average is`), chalk.green(result.fastestAvarege))
-        console.log(chalk.bold.yellow(result.slowest), chalk.blue(`request average is`), chalk.yellow(result.slowestAvarege))
-      }
+
+      console.log(chalk.blue(`Both are awesome but`), chalk.bold.green(result.fastest), chalk.blue(`is`), chalk.red(result.diff), chalk.blue(`faster than`), chalk.bold.yellow(result.slowest))
+      console.log(chalk.bold.green(result.fastest), chalk.blue(`request average is`), chalk.green(result.fastestAvarege))
+      console.log(chalk.bold.yellow(result.slowest), chalk.blue(`request average is`), chalk.yellow(result.slowestAvarege))
     })
   })
 }

--- a/lib/autocannon.js
+++ b/lib/autocannon.js
@@ -50,9 +50,9 @@ module.exports.compare = (a, b) => {
   const resA = require(`${resultsDirectory}/${a}.json`)
   const resB = require(`${resultsDirectory}/${b}.json`)
   const comp = compare(resA, resB)
-  if (comp.equal) {
-    return true
-  } else if (comp.aWins) {
+  const diff = parseFloat(comp.requests.difference)
+
+  if (diff >= 0) {
     return {
       diff: comp.requests.difference,
       fastest: a,


### PR DESCRIPTION
So this fixes an issue I've been seeing sometimes, where `autocannon-compare` returns `false` for all comparisons and throws the UI in wack. I know #17 is going on and I think the "is equal" was mentioned in another thread, so this just remove the equal and shows the text plus the two average req/s for both frameworks.

Here is the weirdness I'm seeing currently, which this fixes:
```
$ node benchmark-compare.js 
? What's your first pick? connect-router
? What's your second one? fastify
Both are awesome but fastify is 4.08% faster than connect-router
fastify request average is 38025.6
connect-router request average is 36534.4

$ node benchmark-compare.js 
? What's your first pick? fastify
? What's your second one? connect-router
Both are awesome but connect-router is -3.92% faster than fastify
connect-router request average is 36534.4
fastify request average is 38025.6
```