### PR TITLE
Use logger: false in fastify

### DIFF
--- a/benchmarks/fastify-big-json.js
+++ b/benchmarks/fastify-big-json.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fastify = require('fastify')()
+const fastify = require('fastify')({ logger: false })
 
 const opts = {
   schema: {

--- a/benchmarks/fastify.js
+++ b/benchmarks/fastify.js
@@ -1,4 +1,4 @@
-const fastify = require('fastify')()
+const fastify = require('fastify')({ logger: false })
 
 const schema = {
   schema: {


### PR DESCRIPTION
Conceptually this is similar to `app.disable('etag')`  in express. The other frameworks have no embedded logger.