### PR TITLE
Update hapi deps

### DIFF
--- a/benchmarks/hapi.js
+++ b/benchmarks/hapi.js
@@ -5,7 +5,7 @@ require('make-promises-safe')
 const Hapi = require('hapi')
 
 async function start () {
-  const server = Hapi.server({ port: 3000 })
+  const server = Hapi.server({ port: 3000, debug: false })
 
   server.route({
     method: 'GET',
@@ -14,9 +14,10 @@ async function start () {
       cache: false,
       response: {
         ranges: false
-      }
+      },
+      state: { parse: false }
     },
-    handler: async function (request, h) {
+    handler: function (request, h) {
       return { hello: 'world' }
     }
   })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.16.2",
     "fastify": "^0.32.0",
     "frameguard": "^3.0.0",
-    "hapi": "^17.0.0-rc10",
+    "hapi": "^17.0.1",
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.1.0",
     "ienoopen": "^1.0.0",


### PR DESCRIPTION
Some minor changes to the hapi script. Note that there is no need to declare the handler as `async` because that just adds a next tick for no reason. I turned off debugging which adds some listeners, as well as parsing of cookies. These don't make a noticeable difference but make it more obvious we are turning off functionality other frameworks don't all offer out of the box.

Last, I don't know the reason but the numbers I get seems to be best when running the test for at least 30 seconds. This is pretty consistent. Testing hapi and express:

5s:
- hapi 16,546
- express 17,266

20s:
- hapi 16803
- express 18324

30s:
- hapi 18257
- express 18608

45s:
- hapi 19010
- express 18282

For hapi, 45s seems to be consistently the best sample point.