### PR TITLE
refactor(benchmarks): remove optional name form restify

### DIFF
--- a/benchmarks/restify.js
+++ b/benchmarks/restify.js
@@ -2,7 +2,7 @@
 
 const restify = require('restify')
 
-const server = restify.createServer({ name: '' })
+const server = restify.createServer()
 server.get('/', function (req, res) {
   res.send({ hello: 'world' })
 })


### PR DESCRIPTION
It shouldn't make any difference, but `name` is unnecessary here, it's an optional argument.