### PR TITLE
add spirit to benchmarks

### DIFF
--- a/benchmark-bench.js
+++ b/benchmark-bench.js
@@ -60,6 +60,12 @@ function select (callback) {
           name: 'micro-router'
         },
         {
+          name: 'spirit'
+        },
+        {
+          name: 'spirit-router'
+        },
+        {
           name: 'trek-engine'
         },
         {
@@ -136,6 +142,8 @@ inquirer.prompt([
       'fastify',
       'micro',
       'micro-router',
+      'spirit',
+      'spirit-router',
       'trek-engine',
       'trek-engine-router'
     ])

--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -24,6 +24,8 @@ let choices = [
   'fastify-big-json',
   'micro',
   'micro-router',
+  'spirit',
+  'spirit-router',
   'trek-engine',
   'trek-engine-router'
 ]

--- a/benchmarks/spirit-router.js
+++ b/benchmarks/spirit-router.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const http = require('http')
+
+const {adapter} = require('spirit').node
+const route = require('spirit-router')
+
+const hello = () => {
+  return { hello: 'world' }
+}
+
+const app = route.define([
+  route.get('/', hello)
+])
+
+http.createServer(adapter(app)).listen(3000)

--- a/benchmarks/spirit.js
+++ b/benchmarks/spirit.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const http = require('http')
+
+const {adapter, response} = require('spirit').node
+
+const app = (req) => {
+  return response({ hello: 'world' }).type('json')
+}
+
+http.createServer(adapter(app)).listen(3000)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "ora": "^1.3.0",
     "restify": "^6.3.2",
     "router": "^1.3.2",
+    "spirit": "^0.6.1",
+    "spirit-router": "^0.5.0",
     "take-five": "^1.3.4",
     "total.js": "^2.8.0",
     "trek-engine": "^1.0.5",


### PR DESCRIPTION
Hello,

Nice benchmark project. Makes it easier for everyone to compare. I had a request to see how my project compared to fastify and added to it. (https://github.com/spirit-js/spirit/issues/19)

How can I get the results published to the table @ https://github.com/fastify/fastify ?

I know my project isn't as popular as express, fastify, koa, hapi, etc. But I think it definitely takes a different approach design wise and implementing compared to other projects and has some interesting results, so hopefully you guys are willing to include it.