### PR TITLE
chore(restify): upgrade to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "microrouter": "^3.1.1",
     "ora": "^1.4.0",
     "polka": "^0.3.4",
-    "restify": "^6.3.4",
+    "restify": "^7.1.0",
     "router": "^1.3.2",
     "spirit": "^0.6.1",
     "spirit-router": "^0.5.0",


### PR DESCRIPTION
 Both are awesome but fastify is 17.7% faster than restify

 Both are awesome but restify is 44.63% faster than koa
 Both are awesome but restify is 55.73% faster than express
 Both are awesome but restify is 58.31% faster than hapi

 • fastify request average is 33734.4
 • restify request average is 28660.8
 • koa request average is 19816
 • express request average is 18404
 • hapi request average is 18104

Can we update this page: https://www.fastify.io/benchmarks/ ? ;)