### PR TITLE
Feature #62 add percentage value to cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ benchmark [arguments (optional)]
 * `-h`: Help on how to use the tool.
 * `compare`: Get comparative data for your benchmarks.
 
-> You may also compare all test results, at once, in a single table; `benchmark compare -t`
+> You may also compare all test results, at once, in a single table; `benchmark compare -t` 
+
+> You can also extend the comparsion table with percentage values based on fastest result; `benchmark compare -t -p`
 
 # Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ benchmark [arguments (optional)]
 
 > You may also compare all test results, at once, in a single table; `benchmark compare -t` 
 
-> You can also extend the comparsion table with percentage values based on fastest result; `benchmark compare -t -p`
+> You can also extend the comparsion table with percentage values based on fastest result; `benchmark compare -p`
 
 # Benchmarks
 

--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -15,15 +15,16 @@ let choices = readdirSync(resultsPath)
   .sort()
   .map((choice) => choice.replace('.json', ''))
 
-const showAsTable = process.argv[2] === '-t'
+const argvs = process.argv.slice(2)
+const bold = (writeBold, str) => writeBold ? chalk.bold(str) : str
+
 if (!choices.length) {
   console.log(chalk.red('Benchmark to gather some results to compare.'))
-} else if (showAsTable) {
+} else if (argvs.indexOf('-t') > -1 && argvs.indexOf('-p') === -1) {
   const table = new Table({
     head: ['', 'Version', 'Router', 'Requests/s', 'Latency', 'Throughput/Mb']
   })
 
-  const bold = (writeBold, str) => writeBold ? chalk.bold(str) : str
   choices.forEach((result) => {
     let data = readFileSync(`${resultsPath}/${result}.json`)
     data = JSON.parse(data.toString())
@@ -36,6 +37,47 @@ if (!choices.length) {
       bold(beBold, data.requests.average),
       bold(beBold, data.latency.average),
       bold(beBold, (data.throughput.average / 1024 / 1024).toFixed(2))
+    ])
+  })
+
+  console.log(table.toString())
+} else if (argvs.indexOf('-t') > -1 && argvs.indexOf('-p') > -1) {
+  let data = []
+  choices.forEach(file => {
+    let content = readFileSync(`${resultsPath}/${file}.json`)
+    data.push(JSON.parse(content.toString()))
+  })
+  data.sort((a, b) => {
+    return parseFloat(b.requests.mean) - parseFloat(a.requests.mean)
+  })
+  const base = Object.assign({}, {
+    name: data[0].server,
+    request: data[0].requests.mean,
+    latency: data[0].latency.mean,
+    throughput: data[0].throughput.mean
+  })
+  const table = new Table({
+    head: [
+      '',
+      'Version',
+      'Router',
+      `Requests/s\n(% of ${base.name})`,
+      `Latency\n(% of ${base.name})`,
+      `Throughput/Mb\n(% of ${base.name})`
+    ]
+  })
+  data.forEach(result => {
+    const beBold = result.server === 'fastify'
+    const { version = 'N/A', hasRouter = false } = info(result.server) || {}
+    const getPct = (base, value) => ((value / base * 100).toFixed(2))
+
+    table.push([
+      bold(beBold, chalk.blue(result.server)),
+      bold(beBold, version),
+      bold(beBold, hasRouter ? '✓' : '✗'),
+      bold(beBold, `${result.requests.mean}\n(${getPct(base.request, result.requests.mean)})`),
+      bold(beBold, `${result.latency.mean}\n(${getPct(base.latency, result.latency.mean)})`),
+      bold(beBold, `${(result.throughput.mean / 1024 / 1024).toFixed(2)}\n(${getPct(base.throughput, result.throughput.mean)})`)
     ])
   })
 

--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -21,7 +21,6 @@ let choices = readdirSync(resultsPath)
   .sort()
   .map((choice) => choice.replace('.json', ''))
 
-const argvs = process.argv.slice(2)
 const bold = (writeBold, str) => writeBold ? chalk.bold(str) : str
 
 if (!choices.length) {
@@ -47,7 +46,7 @@ if (!choices.length) {
   })
 
   console.log(table.toString())
-} else if (commander.percentage && commander.table) {
+} else if (commander.percentage) {
   let data = []
   choices.forEach(file => {
     let content = readFileSync(`${resultsPath}/${file}.json`)

--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -8,6 +8,12 @@ const { join } = require('path')
 const { readdirSync, readFileSync } = require('fs')
 const { compare } = require('./lib/autocannon')
 const { info } = require('./lib/packages')
+const commander = require('commander')
+
+commander
+  .option('-t, --table', 'table')
+  .option('-p, --percentage', 'percentage')
+  .parse(process.argv)
 
 const resultsPath = join(process.cwd(), 'results')
 let choices = readdirSync(resultsPath)
@@ -20,7 +26,7 @@ const bold = (writeBold, str) => writeBold ? chalk.bold(str) : str
 
 if (!choices.length) {
   console.log(chalk.red('Benchmark to gather some results to compare.'))
-} else if (argvs.indexOf('-t') > -1 && argvs.indexOf('-p') === -1) {
+} else if (commander.table && !commander.percentage) {
   const table = new Table({
     head: ['', 'Version', 'Router', 'Requests/s', 'Latency', 'Throughput/Mb']
   })
@@ -41,7 +47,7 @@ if (!choices.length) {
   })
 
   console.log(table.toString())
-} else if (argvs.indexOf('-t') > -1 && argvs.indexOf('-p') > -1) {
+} else if (commander.percentage && commander.table) {
   let data = []
   choices.forEach(file => {
     let content = readFileSync(`${resultsPath}/${file}.json`)


### PR DESCRIPTION
Hi! This is the first attempt to introuduce feature #62.

#### Changes
- Introduce `-p` argument
- Adds percentage value to the full comparsion table based on the fastest result with `benchmark compare -t -p`
- Also sorts table results based on `requests.mean` value. The sorting is hardoded. 