### PR TITLE
Adding woodland benchmark

### DIFF
--- a/benchmarks/woodland.js
+++ b/benchmarks/woodland.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const app = require('woodland')()
+
+app.get('/', (req, res) => res.json({ hello: 'world' }))
+
+require('http').createServer(app.route).listen(3000)

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -33,6 +33,7 @@ const packages = {
   'trek-engine': { extra: true },
   'trek-router': { extra: true, hasRouter: true },
   vapr: { hasRouter: true },
+  woodland: { hasRouter: true },
   'server-base': {},
   'server-base-router': { hasRouter: true }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "trek-engine": "^1.0.5",
     "trek-router": "^1.2.0",
     "vapr": "^0.5.1",
+    "woodland": "^7.2.10",
     "x-xss-protection": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Adding `woodland`

> Lightweight HTTP/HTTP2 router with automatic Allow & CORS headers.