### PR TITLE
New: polkadot

### DIFF
--- a/benchmarks/polkadot.js
+++ b/benchmarks/polkadot.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const polkadot = require('polkadot');
+
+polkadot(function (req, res) {
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify({ hello: 'world' }));
+}).listen(3000);

--- a/benchmarks/polkadot.js
+++ b/benchmarks/polkadot.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const polkadot = require('polkadot');
+const polkadot = require('polkadot')
 
 polkadot(function (req, res) {
-  res.setHeader('content-type', 'application/json; charset=utf-8');
-  res.end(JSON.stringify({ hello: 'world' }));
-}).listen(3000);
+  res.setHeader('content-type', 'application/json; charset=utf-8')
+  res.end(JSON.stringify({ hello: 'world' }))
+}).listen(3000)

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -24,6 +24,7 @@ const packages = {
   microrouter: { extra: true, hasRouter: true },
   'micro-route': { extra: true, hasRouter: true },
   polka: { hasRouter: true },
+  polkadot: { hasRouter: false },
   rayo: { hasRouter: true },
   restify: { hasRouter: true },
   spirit: { extra: true },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "microrouter": "^3.1.3",
     "ora": "^3.1.0",
     "polka": "^0.5.2",
+    "polkadot": "^1.0.0",
     "rayo": "^1.2.9",
     "restify": "^8.0.0",
     "router": "^1.3.3",


### PR DESCRIPTION
Adds [`polkadot`](https://github.com/lukeed/polkadot) to the benchmark, which is most comparable to `micro`. I could add another candidate that pairs polkadot with a router (can use any), though not sure if there's much purpose to it nor how to label it 🙃 

Here are the results on my machine, hand-picking some items & using the standard autocannon settings

```
┌──────────┬────────┬────────────┬─────────┬───────────────┐
│          │ Router │ Requests/s │ Latency │ Throughput/Mb │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ bare     │ ✗      │ 58004.0    │ 1.66    │ 9.07          │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ fastify  │ ✓      │ 58606.4    │ 1.65    │ 9.17          │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ micro    │ ✗      │ 55929.6    │ 1.73    │ 8.75          │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ polka    │ ✓      │ 57280.8    │ 1.68    │ 8.96          │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ polkadot │ ✗      │ 58594.4    │ 1.43    │ 9.16          │
├──────────┼────────┼────────────┼─────────┼───────────────┤
│ rayo     │ ✓      │ 56216.0    │ 1.72    │ 8.79          │
└──────────┴────────┴────────────┴─────────┴───────────────┘
```