### PR TITLE
compare: fix Markdown table formatting

### DIFF
--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -51,7 +51,7 @@ if (!choices.length) {
     head: ['', 'Router', 'Requests/s', 'Latency', 'Throughput/Mb']
   })
   if (commander.commandlineMdTable) {
-    table.push([':--', '--:', ':-:', '--:', '--:', '--:'])
+    table.push([':--', '--:', ':-:', '--:', '--:'])
   }
 
   choices.forEach((result) => {


### PR DESCRIPTION
`compare -tc` result outputs one extra `--:`, which breaks formatting:

```
  |         | Router | Requests/s | Latency | Throughput/Mb |
  | :--     | --:    | :-:        | --:     | --:           | --: |
  | fastify | ✓      | 42029.9    | 2.27    | 6.57          |
  | restify | ✓      | 29657.1    | 3.28    | 4.70          |
```

|         | Router | Requests/s | Latency | Throughput/Mb |
| :--     | --:    | :-:        | --:     | --:           | --: |
| fastify | ✓      | 42029.9    | 2.27    | 6.57          |
| restify | ✓      | 29657.1    | 3.28    | 4.70          |

Removing the extra `--:` makes the formatting work as expected:

```
  |         | Router | Requests/s | Latency | Throughput/Mb |
  | :--     | --:    | :-:        | --:     | --:           |
  | fastify | ✓      | 42029.9    | 2.27    | 6.57          |
  | restify | ✓      | 29657.1    | 3.28    | 4.70          |
```

  |         | Router | Requests/s | Latency | Throughput/Mb |
  | :--     | --:    | :-:        | --:     | --:           |
  | fastify | ✓      | 42029.9    | 2.27    | 6.57          |
  | restify | ✓      | 29657.1    | 3.28    | 4.70          |

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
