### PR TITLE
Set content-type for 0http

### DIFF
--- a/benchmarks/0http.js
+++ b/benchmarks/0http.js
@@ -4,6 +4,7 @@ const cero = require('0http')
 const { router, server } = cero()
 
 router.get('/', (req, res) => {
+  res.setHeader('content-type', 'application/json; charset=utf-8')
   res.end(JSON.stringify({ hello: 'world' }))
 })
 


### PR DESCRIPTION
The 0http framework added in #125 is not comparing apple-to-apples, as the HTTP response is different between the various frameworks. It is missing the `content-type` header.

---

I noticed this by looking at the README, as you can see

|                         | Version | Router | Requests/s | Latency | Throughput/Mb |
| :--                      | --:     | --:    | :-:        | --:     | --:           |
| 0http                    | 3.0.0   | ✓      | 63402.4    | 1.45    | 8.47          |
| fastify                  | 3.8.0   | ✓      | 61704.8    | 1.53    | 11.00         |

`0http` does more req/s at a _lower_ throughput, i.e. the content for each of those is smaller.