### PR TITLE
build(deps-dev): bump standard from 12.0.1 to 16.0.3

### DIFF
--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -29,22 +29,22 @@ if (!choices.length) {
 } else if (commander.table && !commander.percentage) {
   const tableSeparatorChars = commander.commandlineMdTable
     ? {
-      top: '',
-      'top-left': '',
-      'top-mid': '',
-      'top-right': '',
-      bottom: '',
-      'bottom-left': '',
-      'bottom-mid': '',
-      'bottom-right': '',
-      mid: '',
-      'left-mid': '',
-      'mid-mid': '',
-      'right-mid': '',
-      left: '|',
-      right: '|',
-      middle: '|'
-    }
+        top: '',
+        'top-left': '',
+        'top-mid': '',
+        'top-right': '',
+        bottom: '',
+        'bottom-left': '',
+        'bottom-mid': '',
+        'bottom-right': '',
+        mid: '',
+        'left-mid': '',
+        'mid-mid': '',
+        'right-mid': '',
+        left: '|',
+        right: '|',
+        middle: '|'
+      }
     : {}
   const table = new Table({
     chars: tableSeparatorChars,
@@ -56,7 +56,7 @@ if (!choices.length) {
 
   const arrayObjChoices = []
   choices.map(file => {
-    let content = readFileSync(`${resultsPath}/${file}.json`)
+    const content = readFileSync(`${resultsPath}/${file}.json`)
     return JSON.parse(content.toString())
   })
     .sort((a, b) => {
@@ -96,9 +96,9 @@ if (!choices.length) {
   console.log(table.toString())
   writeFileSync('benchmark-results.json', JSON.stringify(arrayObjChoices), 'utf8')
 } else if (commander.percentage) {
-  let data = []
+  const data = []
   choices.forEach(file => {
-    let content = readFileSync(`${resultsPath}/${file}.json`)
+    const content = readFileSync(`${resultsPath}/${file}.json`)
     data.push(JSON.parse(content.toString()))
   })
   data.sort((a, b) => {

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -43,7 +43,7 @@ const packages = {
   'yeps-router': { extra: true, package: 'yeps', hasRouter: true }
 }
 
-let choices = []
+const choices = []
 Object.keys(packages).forEach(pkg => {
   if (!packages[pkg].version) {
     const module = dependencies[pkg] ? pkg : packages[pkg].package

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
   },
   "devDependencies": {
     "snazzy": "^9.0.0",
-    "standard": "^12.0.1"
+    "standard": "^16.0.3"
   }
 }


### PR DESCRIPTION
Linted with latest version as well, which was causing #146 to fail

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
