### PR TITLE
chore: update benchmark-compare and github action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,34 +14,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.1.5
       with:
-        node-version: 12
+        node-version: 14
+
     - name: run benchmarks
       run: |
         npm install
         npm start y 100 10 40
-    - name: commit benchmarks
+
+    - name: compare results
       run: |
-        node_version=$(node --version)
-        benchmark_title=$(cat << EOF
-        # Benchmarks
-        * __Machine:__ $(uname -a) | $(node -r os -p "\`\${os.cpus().length} vCPUs | \${Math.ceil(os.totalmem() / (Math.pow(1024, 3)))}GB\`").
-        * __Method:__ \`autocannon -c 100 -d 40 -p 10 localhost:3000\` (two rounds; one to warm-up, one to measure).
-        * __Node:__ \`$node_version\`
-        * __Run:__ $(date)
-        EOF)
-        benchmark_table=$(node benchmark-compare.js -t -c)
-        strip_readme=$(node -r fs -p 'fs.readFileSync("./README.md", "utf-8").split(/# Benchmarks/)[0]')
-        git checkout master
-        echo -e "${strip_readme:?}\n${benchmark_title:?}\n\n${benchmark_table}" > README.md
-        git add README.md
-        git add benchmark-results.json
-        git config user.name 'Github Actions'
-        git config user.email '<>'
-        git commit -m "Add new benchmarks to README.md"
-    - name: push benchmark changes
-      uses: ad-m/github-push-action@master
+        node ./benchmark compare -t
+        node ./benchmark compare -u
+
+    - name: commit and push updated results
+      uses: github-actions-x/commit@v2.8
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        push-branch: 'master'
+        commit-message: 'chore: update benchmark results'
+        force-add: 'true'
+        files: benchmark-results.json README.md
+        name: Github Actions
+        email: <>


### PR DESCRIPTION
I was trying to test changes in #163 in my fork, it seemes `benchmark-compare` is stalled and not working and containes lots of duplicate logic. So I tried to rewrite and improve it. Also updated github action accordingly to use node LTS, new `compare -u` script to update readme and [github-actions-x/commit](https://github.com/github-actions-x/commit) to simplify commit and push step. Tried action and script in [my fork](https://github.com/pi0/benchmarks) with a subset of `benchmarks/`.

Note: Percentage flavor is removed since wasn't sure this PR and that feature is still wanted or not

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
