### PR TITLE
chore: revert ora to v5 non pure ESM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: 'ora'
+      versions: ['6.x']

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "micro": "^9.3.3",
     "micro-route": "^2.5.0",
     "microrouter": "^3.1.3",
-    "ora": "^6.0.0",
+    "ora": "^5.4.1",
     "polka": "^0.5.2",
     "polkadot": "^1.0.0",
     "rayo": "^1.2.9",


### PR DESCRIPTION
`ora` in the latest major version (v6.x.x) was moved to pure ESM.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
