### PR TITLE
add IPv4 host

### DIFF
--- a/benchmarks/fastify.js
+++ b/benchmarks/fastify.js
@@ -21,4 +21,4 @@ fastify.get('/', schema, function (req, reply) {
   reply.send({ hello: 'world' })
 })
 
-fastify.listen(3000)
+fastify.listen(3000, '127.0.0.1')


### PR DESCRIPTION
After the https://github.com/fastify/fastify/pull/3606 will land in Fastify v4, there will be two HTTP servers spinning up on `localhost`.

So, the benchmark should start just one server tho