### PR TITLE
Revert "chore(deps): bump inquirer from 8.2.4 to 9.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.1.0",
     "ienoopen": "^1.0.0",
-    "inquirer": "^9.1.0",
+    "inquirer": "^8.0.0",
     "koa": "^2.7.0",
     "koa-isomorphic-router": "^1.0.0",
     "koa-router": "^10.0.0",


### PR DESCRIPTION
Reverts fastify/benchmarks#247 (It uses ESM only)