### PR TITLE
Adds benchmark Fastify + TRPC router adapter

### DIFF
--- a/benchmarks/fastify.js
+++ b/benchmarks/fastify.js
@@ -21,4 +21,4 @@ fastify.get('/', schema, function (req, reply) {
   reply.send({ hello: 'world' })
 })
 
-fastify.listen(3000, '127.0.0.1')
+fastify.listen({ port: 3000, host: '127.0.0.1' })

--- a/benchmarks/trpc-router.js
+++ b/benchmarks/trpc-router.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const trpc = require('@trpc/server')
+const { fastifyTRPCPlugin } = require('@trpc/server/adapters/fastify')
+
+const fastify = require('fastify')()
+
+const appRouter = trpc
+  .router()
+  .query('', {
+    resolve: () => {
+      return { hello: 'world' }
+    },
+  })
+
+fastify.register(fastifyTRPCPlugin, {
+  prefix: '',
+  trpcOptions: { router: appRouter, createContext: () => {} },
+})
+
+fastify.listen({ port: 3000, host: '127.0.0.1' })

--- a/benchmarks/trpc-router.js
+++ b/benchmarks/trpc-router.js
@@ -10,12 +10,12 @@ const appRouter = trpc
   .query('', {
     resolve: () => {
       return { hello: 'world' }
-    },
+    }
   })
 
 fastify.register(fastifyTRPCPlugin, {
   prefix: '',
-  trpcOptions: { router: appRouter, createContext: () => {} },
+  trpcOptions: { router: appRouter, createContext: () => {} }
 })
 
 fastify.listen({ port: 3000, host: '127.0.0.1' })

--- a/benchmarks/trpc-router.js
+++ b/benchmarks/trpc-router.js
@@ -5,6 +5,7 @@ const { fastifyTRPCPlugin } = require('@trpc/server/adapters/fastify')
 
 const fastify = require('fastify')()
 
+// https://trpc.io/docs/v9/router
 const appRouter = trpc
   .router()
   .query('', {
@@ -18,4 +19,8 @@ fastify.register(fastifyTRPCPlugin, {
   trpcOptions: { router: appRouter, createContext: () => {} }
 })
 
+// Route URL is composed by prefix + query() first string param.
+// In this benchmark, assigning an empty string to both of them is a way for exposing URL "/".
+// A more realistic case would be having prefix="/trpc" and query('tasks'),
+// which would expose the URL "/trpc/tasks"
 fastify.listen({ port: 3000, host: '127.0.0.1' })

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -36,6 +36,7 @@ const packages = {
   'total.js': { hasRouter: true },
   'trek-engine': { extra: true },
   'trek-router': { extra: true, hasRouter: true },
+  'trpc-router': { extra: true, hasRouter: true, package: '@trpc/server' },
   vapr: { hasRouter: true },
   'server-base': {},
   'server-base-router': { hasRouter: true },

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "0http": "^3.0.0",
     "@hapi/hapi": "^20.0.1",
     "@leizm/web": "^2.7.0",
     "@trpc/server": "^9.27.2",
-    "0http": "^3.0.0",
     "autocannon": "^7.0.1",
     "autocannon-compare": "^0.4.0",
     "benchmark": "^2.1.4",
@@ -40,7 +40,7 @@
     "dns-prefetch-control": "^0.3.0",
     "egg": "^3.0.0",
     "express": "^4.16.4",
-    "fastify": "^4.5.3",
+    "fastify": "^4.0.2",
     "foxify": "^0.10.20",
     "frameguard": "^4.0.0",
     "hide-powered-by": "^1.0.0",
@@ -72,8 +72,7 @@
     "vapr": "^0.6.0",
     "x-xss-protection": "^2.0.0",
     "yeps": "^1.1.1",
-    "yeps-router": "^1.2.0",
-    "zod": "^3.18.0"
+    "yeps-router": "^1.2.0"
   },
   "devDependencies": {
     "snazzy": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "0http": "^3.0.0",
     "@hapi/hapi": "^20.0.1",
     "@leizm/web": "^2.7.0",
+    "@trpc/server": "^9.27.2",
+    "0http": "^3.0.0",
     "autocannon": "^7.0.1",
     "autocannon-compare": "^0.4.0",
     "benchmark": "^2.1.4",
@@ -39,7 +40,7 @@
     "dns-prefetch-control": "^0.3.0",
     "egg": "^3.0.0",
     "express": "^4.16.4",
-    "fastify": "^4.0.2",
+    "fastify": "^4.5.3",
     "foxify": "^0.10.20",
     "frameguard": "^4.0.0",
     "hide-powered-by": "^1.0.0",
@@ -71,7 +72,8 @@
     "vapr": "^0.6.0",
     "x-xss-protection": "^2.0.0",
     "yeps": "^1.1.1",
-    "yeps-router": "^1.2.0"
+    "yeps-router": "^1.2.0",
+    "zod": "^3.18.0"
   },
   "devDependencies": {
     "snazzy": "^9.0.0",


### PR DESCRIPTION
I am adding an example of Fastify using [TRPC and its Fastify adapter](https://trpc.io/docs/v9/fastify) for defining API routes.

It's my first contribution, I am checking if I am missing anything for the PR.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
