### PR TITLE
feat(#263): replace istanbuljs to galatajs

### DIFF
--- a/benchmarks/galatajs.js
+++ b/benchmarks/galatajs.js
@@ -1,6 +1,6 @@
 'use strict'
-const { createApp } = require('@istanbul/app')
-const { createHttpServer, createRouter } = require('@istanbul/http')
+const { createApp } = require('@galatajs/app')
+const { createHttpServer, createRouter } = require('@galatajs/http')
 
 const app = createApp()
 const server = createHttpServer()

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -21,7 +21,7 @@ const packages = {
   h3: { package: 'h3' },
   'h3-router': { hasRouter: true, package: 'h3' },
   hapi: { hasRouter: true, package: '@hapi/hapi' },
-  istanbul: { hasRouter: true, package: '@istanbul/app' },
+  galatajs: { hasRouter: true, package: '@galatajs/app' },
   koa: {},
   'koa-isomorphic-router': { extra: true, hasRouter: true },
   'koa-router': { extra: true, hasRouter: true },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "0http": "^3.0.0",
     "@hapi/hapi": "^20.0.1",
-    "@istanbul/app": "^0.0.33",
-    "@istanbul/http": "^0.0.24",
+    "@galatajs/app": "^0.1.1",
+    "@galatajs/http": "^0.1.1",
     "@leizm/web": "^2.7.0",
     "@trpc/server": "^9.27.2",
     "autocannon": "^7.0.1",


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I had a PR for the istanbuljs framework I developed yesterday and then got a feedback that the name istanbuljs was confusing. It was confusing when you think about it. I renamed the package name to galatajs. 

fixed #263 