### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmarks/bare.cjs
+++ b/benchmarks/bare.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const server = require('http').createServer(function (req, res) {
+const server = require('node:http').createServer(function (req, res) {
   res.setHeader('content-type', 'application/json; charset=utf-8')
   res.end(JSON.stringify({ hello: 'world' }))
 })

--- a/benchmarks/h3-router.cjs
+++ b/benchmarks/h3-router.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createServer } = require('http')
+const { createServer } = require('node:http')
 const { createApp, toNodeListener, eventHandler, createRouter } = require('h3')
 
 const app = createApp()

--- a/benchmarks/h3.cjs
+++ b/benchmarks/h3.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createServer } = require('http')
+const { createServer } = require('node:http')
 const { createApp, toNodeListener, eventHandler } = require('h3')
 
 const app = createApp()

--- a/benchmarks/server-base-router.cjs
+++ b/benchmarks/server-base-router.cjs
@@ -1,4 +1,4 @@
-require('http')
+require('node:http')
   .createServer(
     require('server-base-router')({
       '@setup' (ctx) {

--- a/benchmarks/spirit-router.cjs
+++ b/benchmarks/spirit-router.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 
 const { adapter } = require('spirit').node
 const route = require('spirit-router')

--- a/benchmarks/spirit.cjs
+++ b/benchmarks/spirit.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 
 const { adapter, response } = require('spirit').node
 

--- a/benchmarks/vapr.cjs
+++ b/benchmarks/vapr.cjs
@@ -8,4 +8,4 @@ app.get('/', () => [
   [JSON.stringify({ hello: 'world' })]
 ])
 
-require('http').createServer(app).listen(3000)
+require('node:http').createServer(app).listen(3000)

--- a/benchmarks/yeps-router.cjs
+++ b/benchmarks/yeps-router.cjs
@@ -1,4 +1,4 @@
-const http = require('http')
+const http = require('node:http')
 
 const App = require('yeps')
 const Router = require('yeps-router')

--- a/benchmarks/yeps.cjs
+++ b/benchmarks/yeps.cjs
@@ -1,4 +1,4 @@
-const http = require('http')
+const http = require('node:http')
 const App = require('yeps')
 
 const app = new App()

--- a/metrics/process-results.cjs
+++ b/metrics/process-results.cjs
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
 
 function readableHRTimeMs (diff) {
   return (diff[0] * 1e9 + diff[1]) / 1000000

--- a/metrics/startup-listen.cjs
+++ b/metrics/startup-listen.cjs
@@ -7,6 +7,6 @@ const loadingTime = process.hrtime(start)
 
 server.listen({ port: 3000 }, () => {
   const listenTime = process.hrtime(start)
-  require('fs').writeFileSync(`${__filename}.txt`, `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
+  require('node:fs').writeFileSync(`${__filename}.txt`, `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
   server.close()
 })

--- a/metrics/startup-routes-schema.cjs
+++ b/metrics/startup-routes-schema.cjs
@@ -25,7 +25,7 @@ for (let i = 0; i < routes; ++i) {
 const loadingTime = process.hrtime(start)
 server.listen({ port: 0 }, () => {
   const listenTime = process.hrtime(start)
-  const path = require('path')
-  require('fs').writeFileSync(path.join(__dirname, `${routes}-${path.basename(__filename)}.txt`), `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
+  const path = require('node:path')
+  require('node:fs').writeFileSync(path.join(__dirname, `${routes}-${path.basename(__filename)}.txt`), `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
   server.close()
 })

--- a/metrics/startup-routes.cjs
+++ b/metrics/startup-routes.cjs
@@ -17,7 +17,7 @@ const loadingTime = process.hrtime(start)
 
 server.listen({ port: 0 }, () => {
   const listenTime = process.hrtime(start)
-  const path = require('path')
-  require('fs').writeFileSync(path.join(__dirname, `${routes}-${path.basename(__filename)}.txt`), `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
+  const path = require('node:path')
+  require('node:fs').writeFileSync(path.join(__dirname, `${routes}-${path.basename(__filename)}.txt`), `${loadingTime} | ${listenTime}\n`, { encoding: 'utf-8', flag: 'a' })
   server.close()
 })

--- a/metrics/startup.cjs
+++ b/metrics/startup.cjs
@@ -1,7 +1,7 @@
 'use strict'
 
-const { Worker } = require('worker_threads')
-const path = require('path')
+const { Worker } = require('node:worker_threads')
+const path = require('node:path')
 
 const minSamples = 5
 


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
