### PR TITLE
Rayo is back.

### DIFF
--- a/benchmarks/rayo.cjs
+++ b/benchmarks/rayo.cjs
@@ -1,0 +1,16 @@
+'use strict'
+
+async function run () {
+  const { default: rayo } = await import('rayo')
+
+  const app = rayo({ port: 3000 })
+
+  app.get('/', (req, res) => {
+    res.setHeader('content-type', 'application/json; charset=utf-8')
+    res.end(JSON.stringify({ hello: 'world' }))
+  })
+
+  app.start()
+}
+
+run()

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -26,6 +26,7 @@ const packages = {
   microrouter: { extra: true, hasRouter: true },
   polka: { hasRouter: true },
   polkadot: { hasRouter: false },
+  rayo: { hasRouter: true },
   restana: { hasRouter: true, package: 'restana' },
   restify: { hasRouter: true },
   'server-base': {},

--- a/package.json
+++ b/package.json
@@ -25,16 +25,18 @@
     }
   ],
   "standard": {
-    "ignore": ["lib/packages.js"]
+    "ignore": [
+      "lib/packages.js"
+    ]
   },
   "license": "MIT",
   "dependencies": {
-    "0http": "^3.4.2",
-    "@hapi/hapi": "^21.1.0",
     "@galatajs/app": "^0.1.1",
     "@galatajs/http": "^0.1.2",
+    "@hapi/hapi": "^21.1.0",
     "@leizm/web": "^2.7.3",
     "@trpc/server": "^10.7.0",
+    "0http": "^3.4.2",
     "autocannon": "^7.10.0",
     "autocannon-compare": "^0.4.0",
     "benchmark": "^2.1.4",
@@ -63,6 +65,7 @@
     "ora": "^6.1.2",
     "polka": "^0.5.2",
     "polkadot": "^1.0.0",
+    "rayo": "^1.4.5",
     "restana": "^4.9.7",
     "restify": "^11.0.0",
     "router": "^1.3.7",


### PR DESCRIPTION
`Rayo` was removed here: https://github.com/fastify/benchmarks/commit/4ea026f2aa23db4cc644810d1f1643108a66cf2d

Not sure what the issue was then as `Rayo` is v.18 compatible. Adding it back in.