### PR TITLE
chore: remove make-promises-safe

### DIFF
--- a/benchmarks/hapi.cjs
+++ b/benchmarks/hapi.cjs
@@ -1,7 +1,5 @@
 'use strict'
 
-require('make-promises-safe')
-
 const Hapi = require('@hapi/hapi')
 
 async function start () {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "koa": "^2.14.1",
     "koa-isomorphic-router": "^1.0.1",
     "koa-router": "^12.0.0",
-    "make-promises-safe": "^5.1.0",
     "micro": "^10.0.1",
     "micro-route": "^2.5.0",
     "microrouter": "^3.1.3",


### PR DESCRIPTION
The test workflow still includes Node.js 14, but benchmarks are ran on Node.js 20