### PR TITLE
fix(micro): make micro benchmarks working

### DIFF
--- a/benchmarks/micro-route.cjs
+++ b/benchmarks/micro-route.cjs
@@ -1,12 +1,11 @@
 'use strict'
 
-const micro = require('micro')
+const http = require('http')
+const { send, serve } = require('micro')
 const dispatch = require('micro-route/dispatch')
 
-const handler = (req, res) => micro.send(res, 200, { hello: 'world' })
+const handler = (req, res) => send(res, 200, { hello: 'world' })
 
-const server = micro(
-  dispatch('/', 'GET', handler)
-)
+const server = new http.Server(serve(dispatch('/', 'GET', handler)))
 
 server.listen(3000)

--- a/benchmarks/micro.cjs
+++ b/benchmarks/micro.cjs
@@ -1,9 +1,12 @@
 'use strict'
 
-const micro = require('micro')
+const http = require('http')
+const { serve } = require('micro')
 
-const server = micro(async function (req, res) {
-  return { hello: 'world' }
-})
+const server = new http.Server(
+  serve(async function (req, res) {
+    return { hello: 'world' }
+  })
+)
 
 server.listen(3000)

--- a/benchmarks/microrouter.cjs
+++ b/benchmarks/microrouter.cjs
@@ -1,15 +1,12 @@
 'use strict'
 
-const micro = require('micro')
+const http = require('http')
+const { serve, send } = require('micro')
 const { router, get } = require('microrouter')
 
 const hello = async function (req, res) {
-  return micro.send(res, 200, { hello: 'world' })
+  return send(res, 200, { hello: 'world' })
 }
-const server = micro(
-  router(
-    get('/', hello)
-  )
-)
+const server = new http.Server(serve(router(get('/', hello))))
 
 server.listen(3000)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Micro semantics changed since major update (to version 10) and it seems to be not reflected in the benchmarks. I have fixed the syntax to make the benchmarks working again.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
