### PR TITLE
refactor(adonisjs): remove unneeded async function

### DIFF
--- a/benchmarks/adonisjs.mjs
+++ b/benchmarks/adonisjs.mjs
@@ -22,7 +22,7 @@ const server = new Server(
   defineConfig({})
 )
 
-server.getRouter().get('/', async (ctx) => {
+server.getRouter().get('/', (ctx) => {
   return ctx.response.send({ hello: 'world' })
 })
 


### PR DESCRIPTION
Hey there! 👋🏻

I just noticed that the benchmark code for AdonisJS currently includes an `AsyncFunction` as the route handler, which isn't necessary in this context. Since there's no asynchronous operation within the handler, the `async` keyword is redundant and only introduces an unnecessary promise.

In this PR, I'm removing the `async` keyword to align the implementation more closely with other frameworks.