### PR TITLE
fix: remove strict directive from mjs files, add missing to cjs files

### DIFF
--- a/benchmark-bench.js
+++ b/benchmark-bench.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import inquirer from 'inquirer'
 import bench from './lib/bench.js'
 import { choices, list } from './lib/packages.js'

--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-'use strict'
 
 import { platform, arch, cpus, totalmem } from 'os'
 import { program } from 'commander'

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-'use strict'
 
 import { program } from 'commander'
 

--- a/benchmarks/server-base-router.cjs
+++ b/benchmarks/server-base-router.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 require('node:http')
   .createServer(
     require('server-base-router')({

--- a/benchmarks/server-base.cjs
+++ b/benchmarks/server-base.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 require('server-base')({
   '@setup' (ctx) {
     ctx.middlewareFunctions = []

--- a/lib/autocannon.js
+++ b/lib/autocannon.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import autocannon from 'autocannon'
 import { writeFile as _writeFile, mkdir as _mkdir, access as _access } from 'fs'
 import compare from 'autocannon-compare'

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-'use strict'
 
 import { access } from 'node:fs/promises'
 import { fork } from 'child_process'

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import pkgJson from '../package.json' assert { type: 'json' }
 import { createRequire } from 'module';
 import path from 'path';

--- a/metrics/process-results.cjs
+++ b/metrics/process-results.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('node:fs')
 const path = require('node:path')
 const os = require('node:os')

--- a/metrics/startup-listen.cjs
+++ b/metrics/startup-listen.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 const start = process.hrtime()
 
 const fastify = require('fastify')

--- a/metrics/startup-routes-schema.cjs
+++ b/metrics/startup-routes-schema.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 const start = process.hrtime()
 
 const fastify = require('fastify')

--- a/metrics/startup-routes.cjs
+++ b/metrics/startup-routes.cjs
@@ -1,3 +1,5 @@
+'use strict'
+
 const start = process.hrtime()
 
 const fastify = require('fastify')


### PR DESCRIPTION
- ESM is strict by default, so the `'use strict'` directive is not needed in .mjs files
- Added directive where it was missing in CommonJS files

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
