### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmark-compare.js
+++ b/benchmark-compare.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import { platform, arch, cpus, totalmem } from 'os'
+import { platform, arch, cpus, totalmem } from 'node:os'
 import { program } from 'commander'
 import inquirer from 'inquirer'
 import Table from 'cli-table'
 import chalk from 'chalk'
-import { join } from 'path'
-import { readdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'node:path'
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { info } from './lib/packages.js'
 import { compare } from './lib/autocannon.js'
 

--- a/benchmarks/micro-route.cjs
+++ b/benchmarks/micro-route.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const { send, serve } = require('micro')
 const dispatch = require('micro-route/dispatch')
 

--- a/benchmarks/micro.cjs
+++ b/benchmarks/micro.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const { serve } = require('micro')
 
 const server = new http.Server(

--- a/benchmarks/microrouter.cjs
+++ b/benchmarks/microrouter.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const { serve, send } = require('micro')
 const { router, get } = require('microrouter')
 

--- a/lib/autocannon.js
+++ b/lib/autocannon.js
@@ -1,9 +1,9 @@
 import autocannon from 'autocannon'
-import { writeFile as _writeFile, mkdir as _mkdir, access as _access } from 'fs'
+import { writeFile as _writeFile, mkdir as _mkdir, access as _access } from 'node:fs'
 import compare from 'autocannon-compare'
-import { join } from 'path'
-import { promisify } from 'util'
-import { createRequire } from 'module'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { createRequire } from 'node:module'
 
 const writeFile = promisify(_writeFile)
 const mkdir = promisify(_mkdir)

--- a/lib/bench.js
+++ b/lib/bench.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import { access } from 'node:fs/promises'
-import { fork } from 'child_process'
+import { fork } from 'node:child_process'
 import ora from 'ora'
-import { join } from 'path'
+import { join } from 'node:path'
 import { fire } from './autocannon.js'
-import { fileURLToPath } from 'url'
-import assert from 'assert'
+import { fileURLToPath } from 'node:url'
+import assert from 'node:assert'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,6 +1,6 @@
 import pkgJson from '../package.json' assert { type: 'json' }
-import { createRequire } from 'module';
-import path from 'path';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 
 const packages = {
   '0http': { hasRouter: true, package: '0http' },


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.