### PR TITLE
ci(.github): use latest node version

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
+        check-latest: true
         node-version: 20
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
+        check-latest: true
         node-version: 20
 
     - name: Install dependencies


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5577. This is a batch PR, so may have some issues. Please review changes.