### PR TITLE
use with keyword for import assertions

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,4 +1,4 @@
-import pkgJson from '../package.json' assert { type: 'json' }
+import pkgJson from '../package.json' with { type: 'json' }
 import { createRequire } from 'node:module';
 import path from 'node:path';
 


### PR DESCRIPTION
Without this change, we can't run the benchmarks on Node.js v23.