### PR TITLE
ci(ci): run benchmarks as part of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm i --ignore-scripts
 
       - name: Run tests
-        run: npm test
+        run: npm test && npm start
 
   automerge:
     name: Automerge Dependabot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm i --ignore-scripts
 
       - name: Run tests
-        run: npm test && npm start y
+        run: npm test && npm start y 1 1 1
 
   automerge:
     name: Automerge Dependabot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm i --ignore-scripts
 
       - name: Run tests
-        run: npm test && npm start
+        run: npm test && npm start y
 
   automerge:
     name: Automerge Dependabot PRs

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,6 +1,8 @@
 import pkgJson from '../package.json' with { type: 'json' }
 import { createRequire } from 'node:module';
-import path from 'node:path';
+import { resolve } from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 const packages = {
   '0http': { hasRouter: true, package: '0http' },
@@ -33,13 +35,11 @@ const packages = {
   'trpc-router': { extra: true, hasRouter: true, package: '@trpc/server' },
 }
 
-const require = createRequire(import.meta.url);
-
 const _choices = []
 Object.keys(packages).forEach(pkg => {
   if (!packages[pkg].version) {
     const module = pkgJson.dependencies[pkg] ? pkg : packages[pkg].package
-    const version = require(path.resolve(`node_modules/${module}/package.json`)).version
+    const version = require(resolve(`node_modules/${module}/package.json`)).version
     packages[pkg].version = version
   }
   _choices.push(pkg)


### PR DESCRIPTION
In the absence of unit tests, we should just run the benchmarks (but not commit the results) as part of the CI workflow, to ensure any changes don't break the benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
