### PR TITLE
ci: pin actions to commit-hash

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,10 +25,10 @@ jobs:
       contents: write
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         check-latest: true
         node-version: 20
@@ -45,7 +45,7 @@ jobs:
         node ./benchmark compare -u
 
     - name: Commit and push updated results
-      uses: github-actions-x/commit@v2.9
+      uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         push-branch: 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
       contents: read
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
 
   test:
     name: Test
@@ -36,12 +36,12 @@ jobs:
         node-version: [20, 22]
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}
@@ -63,7 +63,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@e820d631adb1d8ab16c3b93e5afe713450884a4a # v3.11.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -22,10 +22,10 @@ jobs:
       contents: write
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         check-latest: true
         node-version: 20
@@ -39,7 +39,7 @@ jobs:
         npm run metrics:summary
 
     - name: Commit and push updated results
-      uses: github-actions-x/commit@v2.9
+      uses: github-actions-x/commit@722d56b8968bf00ced78407bbe2ead81062d8baa # v2.9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         push-branch: 'main'


### PR DESCRIPTION
Closes https://github.com/fastify/benchmarks/security/code-scanning/1, https://github.com/fastify/benchmarks/security/code-scanning/2, and https://github.com/fastify/benchmarks/security/code-scanning/3.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
