### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     - name: Setup Node
       uses: actions/setup-node@v4


### PR DESCRIPTION
This PR removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485).


The `github-actions-x/commit` action creates its own authentication setup in the shell script by writing to `.netrc`, so should run without these.